### PR TITLE
Bump version to 1.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ruby:2.4-slim
 MAINTAINER Matteo Cerutti <matteo.cerutti@hotmail.co.uk>
 
 ENV PUPPET_FORGE_SERVER_BASEDIR /srv/puppet-forge-server
-ENV PUPPET_FORGE_SERVER_VERSION 1.10.0
+ENV PUPPET_FORGE_SERVER_VERSION 1.10.1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc make ruby-dev rubygems && \


### PR DESCRIPTION
puppet-forge-server 1.10.0 doesn't send back correct values that are expected by newer versions of puppet. See https://github.com/unibet/puppet-forge-server/commit/e1d8250e2921b9cb44ff185b2e0d036c526c96d4